### PR TITLE
surfaceflinger: writepid to the actual stune mount point

### DIFF
--- a/services/surfaceflinger/surfaceflinger.rc
+++ b/services/surfaceflinger/surfaceflinger.rc
@@ -3,4 +3,4 @@ service surfaceflinger /system/bin/surfaceflinger
     user system
     group graphics drmrpc readproc
     onrestart restart zygote
-    writepid /sys/fs/cgroup/stune/foreground/tasks
+    writepid /dev/stune/foreground/tasks


### PR DESCRIPTION
Seems like AOSP missed these out when switching the schedTune
cgroup mount point from /sys/fs/cgroup/stune/ to /dev/stune/.

Reference commit:
11cde56 Mount schedTune cgroup as /dev/stune

Change-Id: Ifbd9ddcaab0fa2a55433a9a66e9a907b6c242204
